### PR TITLE
corrected tascan

### DIFF
--- a/code-list/table.csv
+++ b/code-list/table.csv
@@ -452,7 +452,7 @@ code,variable,description,units,positive,layer,time_cell_method,cf_name,module
 2014,T_SNRDEM,Urban road: snow surface emissivity,,,1,mean,,teb
 2015,T_XT_WAA,wall layer temperatures,K,,109,mean,,teb
 2016,T_XT_WAB,wall layer temperatures,K,,109,mean,,teb
-2017,T_XT_CAN,canyon air temperature,K,,1,mean,tascan,teb
+2017,T_XT_CAN,canyon air temperature,K,,1,point,tascan,teb
 2018,T_XQ_CAN,canyon air specific humidity (kg/kg),1,,1,mean,husscan,teb
 2019,T_XT_BLD,soil layer temperatures under buildings,K,,109,mean,,teb
 2020,T_XT_RD,soil layer temperatures under roads,K,,109,mean,,teb

--- a/code-list/table.csv
+++ b/code-list/table.csv
@@ -452,7 +452,7 @@ code,variable,description,units,positive,layer,time_cell_method,cf_name,module
 2014,T_SNRDEM,Urban road: snow surface emissivity,,,1,mean,,teb
 2015,T_XT_WAA,wall layer temperatures,K,,109,mean,,teb
 2016,T_XT_WAB,wall layer temperatures,K,,109,mean,,teb
-2017,T_XT_CAN,canyon air temperature,K,,1,mean,,teb
+2017,T_XT_CAN,canyon air temperature,K,,1,mean,tascan,teb
 2018,T_XQ_CAN,canyon air specific humidity (kg/kg),1,,1,mean,husscan,teb
 2019,T_XT_BLD,soil layer temperatures under buildings,K,,109,mean,,teb
 2020,T_XT_RD,soil layer temperatures under roads,K,,109,mean,,teb
@@ -467,9 +467,9 @@ code,variable,description,units,positive,layer,time_cell_method,cf_name,module
 2029,B_XQIBLD,building interior temperature,K,,109,mean,,teb
 2030,B_XT_FLR,floor layer temperatures,K,,109,mean,,teb
 2031,B_XT_MAS,Air cooled building internal th. mass temperature,K,,109,mean,,teb
-2032,T2UC,2-meter temperature based on urban canyon approach,K,,105,mean,tascan,teb
+2032,T2UC,2-meter temperature based on urban canyon approach,K,,105,mean,,teb
 2033,T2UCMIN,2-meter temperature minimum based on urban canyon approach,,,105,mean,,teb
 2034,T2UCMAX,2-meter temperature maximum based on urban canyon approach,,,105,mean,,teb
-2035,T2UCI,2-meter instant temperature based on urban canyon approach,K,,105,point,tascan,teb
+2035,T2UCI,2-meter instant temperature based on urban canyon approach,K,,105,point,,teb
 551,SNH,snow depth,m,,1,mean,snd,atmos
 552,CVS,snow cover fraction,1,,1,mean,snc,atmos


### PR DESCRIPTION
tascan was previously matched to the REMO-TEB variable T2UC (2-meter temperature based on urban canyon approach), which is now fixed so tascan uses T_XT_CAN (canyon temperature)